### PR TITLE
🐛 Fix delay command showing old date after update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- cli: Fix `delay` command showing old date after update (#98)
+
 ### Changed
 
 - ical: `DateTime` refactored from enum to struct wrapping new `DateTimeValue` enum


### PR DESCRIPTION
## Summary

Fixed issue #98 where the `delay` command displayed the old date instead of the updated date after successfully delaying a todo or event.

## Changes

- **`update_event` method**: Now extracts the updated event from the calendar component and uses it for both database upsert and return value
- **`update_todo` method**: Now extracts the updated todo from the calendar component and uses it for both database upsert and return value
- Removed the `found` flag and eliminated duplicate search through calendar components
- Used `.ok_or()` pattern for cleaner error handling

## Root Cause

The bug occurred because after applying the patch to the calendar component, the code continued using the old todo/event object from the database for display, instead of extracting the updated component from the calendar file. While the calendar file was correctly updated with the new date, the displayed object still contained the old data.

## Example

**Before fix:**
```
[ ] 32 ! 2026-01-18 09:00 MASKED
~ 
➜ aim delay -t 10d 32 
[ ] 32 ! 2026-01-18 09:00 MASKED  # Still shows old date
```

**After fix:**
```
[ ] 32 ! 2026-01-18 09:00 MASKED
~ 
➜ aim delay -t 10d 32 
[ ] 32 ! 2026-01-28 09:00 MASKED  # Shows updated date
```

Closes #98