### PR TITLE
✨ (ical): Accept LF line endings in addition to CRLF

### DIFF
--- a/cli/src/table.rs
+++ b/cli/src/table.rs
@@ -39,7 +39,7 @@ impl<'a, T, C: TableColumn<T>, S: TableStyle<'a, T, C>> Display for Table<'a, T,
         write!(f, "{}", self.style.table_starting(&columns))?;
         for (i, (cells, data)) in table.into_iter().zip(self.data).enumerate() {
             write!(f, "{}", self.style.row_starting(data))?;
-            for (j, (col, cell)) in columns.iter().zip(cells.into_iter()).enumerate() {
+            for (j, (col, cell)) in columns.iter().zip(cells).enumerate() {
                 write!(f, "{}", self.style.cell_stylize(data, col, cell))?;
 
                 if j < columns.len() - 1 {

--- a/ical/src/fmt/value.rs
+++ b/ical/src/fmt/value.rs
@@ -41,7 +41,7 @@ pub fn write_value<S: StringStorage>(
             } else {
                 KW_BOOLEAN_FALSE
             };
-            write!(f, "{v}",)
+            write!(f, "{v}")
         }
         Value::Date { values, .. } => {
             for (i, date) in values.iter().enumerate() {

--- a/ical/src/lib.rs
+++ b/ical/src/lib.rs
@@ -46,7 +46,7 @@ pub use crate::parameter::{
     AlarmTriggerRelationship, CalendarUserType, Encoding, FreeBusyType, Parameter, ParameterKind,
     ParticipationRole, ParticipationStatus, RecurrenceIdRange, RelationshipType, ValueType,
 };
-pub use crate::parser::{ParseError, parse};
+pub use crate::parser::{ParseError, parse, parse_with_options};
 pub use crate::property::{
     Action, ActionValue, Attachment, AttachmentValue, Attendee, CalendarScale, CalendarScaleValue,
     Categories, Classification, ClassificationValue, Comment, Completed, Contact, Created, Date,
@@ -63,6 +63,7 @@ pub use crate::semantic::{
     TodoStatus, TodoStatusValue, VAlarm, VEvent, VFreeBusy, VJournal, VTimeZone, VTodo,
 };
 pub use crate::string_storage::{Segments, StringStorage};
+pub use crate::syntax::ParseOptions;
 pub use crate::value::{
     RecurrenceFrequency, Value, ValueDate, ValueDateTime, ValueDuration, ValuePeriod,
     ValueRecurrenceRule, ValueText, ValueTime, ValueUtcOffset, WeekDay, WeekDayNum,

--- a/ical/src/parser.rs
+++ b/ical/src/parser.rs
@@ -4,7 +4,7 @@
 
 use crate::semantic::{ICalendar, SemanticError, semantic_analysis, validate_tzids};
 use crate::string_storage::Segments;
-use crate::syntax::SyntaxError;
+use crate::syntax::{ParseOptions, SyntaxError};
 use crate::typed::{TypedError, typed_analysis};
 
 /// Parse an iCalendar component from source code
@@ -60,8 +60,37 @@ use crate::typed::{TypedError, typed_analysis};
 /// }
 /// ```
 pub fn parse(src: &'_ str) -> Result<Vec<ICalendar<Segments<'_>>>, Vec<ParseError<'_>>> {
+    parse_with_options(src, ParseOptions::default())
+}
+
+/// Parse an iCalendar component from source code with custom options
+///
+/// This function performs all four phases of iCalendar parsing:
+/// 1. Lexical analysis
+/// 2. Syntax analysis
+/// 3. Typed analysis
+/// 4. Semantic analysis
+///
+/// The `options` parameter controls syntax-level behavior such as strict
+/// CRLF line ending enforcement.
+///
+/// ## Examples
+///
+/// ```ignore
+/// # use aimcal_ical::parser::{parse_with_options, ParseOptions};
+/// let opts = ParseOptions::new().strict_line_endings(true);
+/// let calendars = parse_with_options(ical_src, opts).unwrap();
+/// ```
+///
+/// # Errors
+///
+/// Returns a vector of [`ParseError`] if any phase of parsing fails.
+pub fn parse_with_options(
+    src: &str,
+    options: ParseOptions,
+) -> Result<Vec<ICalendar<Segments<'_>>>, Vec<ParseError<'_>>> {
     // Syntax analysis (includes tokenization, scanning, and tree building)
-    let syntax_components = crate::syntax::syntax_analysis(src)
+    let syntax_components = crate::syntax::syntax_analysis_with_options(src, options)
         .map_err(|errs| errs.into_iter().map(ParseError::Syntax).collect::<Vec<_>>())?;
 
     let typed_components = typed_analysis(syntax_components)

--- a/ical/src/syntax.rs
+++ b/ical/src/syntax.rs
@@ -42,6 +42,64 @@ pub use tree_builder::{
 
 use std::fmt;
 
+/// Options for controlling syntax analysis behavior.
+///
+/// # Example
+///
+/// ```rust
+/// use aimcal_ical::syntax::{ParseOptions, syntax_analysis};
+///
+/// let src = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nEND:VCALENDAR\r\n";
+///
+/// // Default options (lenient): bare LF is accepted
+/// let components = syntax_analysis(src).unwrap();
+///
+/// // Strict options: bare LF (without preceding CR) is rejected
+/// let opts = ParseOptions::new().strict_line_endings(true);
+/// ```
+#[derive(Debug, Clone, Copy)]
+pub struct ParseOptions {
+    /// When `true`, bare LF (without preceding CR) is reported as an error.
+    ///
+    /// RFC 5545 specifies CRLF (`\r\n`) as the line ending, but many real-world
+    /// iCalendar files use bare LF (`\n`). Default is `false` for compatibility.
+    pub strict_line_endings: bool,
+}
+
+impl Default for ParseOptions {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ParseOptions {
+    /// Create new parse options with default (lenient) settings.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            strict_line_endings: false, // Default to lenient line ending handling
+        }
+    }
+
+    /// Create new parse options with strict settings.
+    #[must_use]
+    pub const fn strict() -> Self {
+        Self {
+            strict_line_endings: true,
+        }
+    }
+
+    /// Set whether to enforce strict CRLF line endings.
+    ///
+    /// When `true`, bare LF (without preceding CR) will be reported as a
+    /// scanning error. Default is `false`.
+    #[must_use]
+    pub const fn strict_line_endings(mut self, strict: bool) -> Self {
+        self.strict_line_endings = strict;
+        self
+    }
+}
+
 /// Parse raw iCalendar components from source text
 ///
 /// This function performs tokenization, scanning, and tree building to produce
@@ -69,14 +127,38 @@ use std::fmt;
 ///
 /// ## Errors
 /// If there are parsing errors, a vector of errors will be returned.
-pub fn syntax_analysis<'src>(
+pub fn syntax_analysis(src: &str) -> Result<Vec<RawComponent<'_>>, Vec<SyntaxError<'_>>> {
+    syntax_analysis_with_options(src, ParseOptions::default())
+}
+
+/// Parse raw iCalendar components from source text with custom options
+///
+/// This function performs tokenization, scanning, and tree building to produce
+/// a hierarchical component tree, using the provided [`ParseOptions`].
+///
+/// # Arguments
+///
+/// * `src` - The iCalendar source text
+/// * `options` - Parse options controlling analysis behavior
+///
+/// # Returns
+///
+/// A result containing either:
+/// - `Ok(Vec<SyntaxComponent>)` - Parsed components
+/// - `Err(Vec<SyntaxError>)` - Syntax errors
+///
+/// # Errors
+///
+/// Returns a vector of [`SyntaxError`] if tokenization, scanning, or tree building fails.
+pub fn syntax_analysis_with_options<'src>(
     src: &'src str,
+    options: ParseOptions,
 ) -> Result<Vec<RawComponent<'src>>, Vec<SyntaxError<'src>>> {
     // Tokenize
     let tokens = tokenize(src);
 
     // Scan tokens into content lines
-    let scan_result = scan_content_lines(src, tokens);
+    let scan_result = scan_content_lines(src, tokens, options);
 
     // Collect scanning errors
     let mut errors: Vec<SyntaxError<'src>> = Vec::new();
@@ -142,6 +224,49 @@ mod tests {
     use super::*;
 
     #[test]
+    fn parses_component_with_lf_endings() {
+        // Default (lenient): bare LF should be accepted
+        let src = "\
+BEGIN:VCALENDAR\n\
+VERSION:2.0\n\
+END:VCALENDAR\n\
+";
+        let result = syntax_analysis(src);
+        assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+        let components = result.unwrap();
+        assert_eq!(components.len(), 1);
+        assert_eq!(components[0].name.resolve().as_ref(), "VCALENDAR");
+    }
+
+    #[test]
+    fn strict_mode_rejects_bare_lf() {
+        let src = "\
+BEGIN:VCALENDAR\n\
+END:VCALENDAR\n\
+";
+        let opts = ParseOptions::new().strict_line_endings(true);
+        let result = syntax_analysis_with_options(src, opts);
+        assert!(result.is_err());
+        let errs = result.unwrap_err();
+        assert!(!errs.is_empty());
+        assert!(errs.iter().any(|e| e.to_string().contains("bare LF")));
+    }
+
+    #[test]
+    fn strict_mode_accepts_crlf() {
+        let src = "\
+BEGIN:VCALENDAR\r\n\
+VERSION:2.0\r\n\
+END:VCALENDAR\r\n\
+";
+        let opts = ParseOptions::new().strict_line_endings(true);
+        let result = syntax_analysis_with_options(src, opts);
+        assert!(result.is_ok(), "Parse failed: {:?}", result.err());
+        let components = result.unwrap();
+        assert_eq!(components.len(), 1);
+    }
+
+    #[test]
     fn parses_component() {
         // Test with the new scanner + tree builder pipeline
         let src = "\
@@ -188,7 +313,7 @@ END:VEVENT\r\n\
     fn parses_property() {
         let src = "SUMMARY:Hello World!\r\n";
         let tokens = tokenize(src);
-        let scan_result = scan_content_lines(src, tokens);
+        let scan_result = scan_content_lines(src, tokens, ParseOptions::default());
 
         assert_eq!(scan_result.lines.len(), 1);
         let line = &scan_result.lines[0];
@@ -199,7 +324,7 @@ END:VEVENT\r\n\
         // Test with parameters
         let src = "DTSTART;TZID=America/New_York:20251113\r\n T100000\r\n";
         let tokens = tokenize(src);
-        let scan_result = scan_content_lines(src, tokens);
+        let scan_result = scan_content_lines(src, tokens, ParseOptions::default());
 
         assert_eq!(scan_result.lines.len(), 1);
         let line = &scan_result.lines[0];
@@ -217,7 +342,7 @@ END:VEVENT\r\n\
     fn parses_parameter() {
         let src = "TZID=America/New_York";
         let tokens = tokenize(src);
-        let scan_result = scan_content_lines(src, tokens);
+        let scan_result = scan_content_lines(src, tokens, ParseOptions::default());
 
         assert_eq!(scan_result.lines.len(), 1);
         let line = &scan_result.lines[0];

--- a/ical/src/syntax/lexer.rs
+++ b/ical/src/syntax/lexer.rs
@@ -24,7 +24,7 @@ pub fn tokenize(src: &str) -> impl IntoIterator<Item = SpannedToken<'_>> {
 
 /// Token emitted by the iCalendar lexer
 #[derive(PartialEq, Eq, Clone, Copy, Logos)]
-#[logos(skip r#"\r\n[ \t]"#)] // skip folding
+#[logos(skip r#"\r?\n[ \t]"#)] // skip folding (CRLF or LF followed by space/tab)
 pub enum Token<'a> {
     /// Double Quote ("), decimal codepoint 22
     #[token(r#"""#)]
@@ -50,9 +50,13 @@ pub enum Token<'a> {
     #[regex(r#"[\t !#$%&'()*+./<>?@\[\\\]\^`\{|\}~]+"#)]
     Symbol(&'a str),
 
-    /// Carriage Return (\r, decimal codepoint 13) followed by Line Feed (\n, decimal codepoint 10)
+    /// Line ending: CRLF (\r\n) or bare LF (\n).
+    ///
+    /// While RFC 5545 specifies CRLF as the line ending, many real-world
+    /// iCalendar files use bare LF. Both are accepted for compatibility.
     #[token("\r\n")]
-    Newline,
+    #[token("\n")]
+    Newline(&'a str),
 
     /// ASCII word characters: 0-9, A-Z, a-z, underscore
     #[regex("[0-9A-Za-z_-]+")]
@@ -76,7 +80,7 @@ impl Display for Token<'_> {
             Self::Semicolon => write!(f, "Semicolon"),
             Self::Equal => write!(f, "Equal"),
             Self::Symbol(s) => write!(f, "Symbol({s})"),
-            Self::Newline => write!(f, "Newline"),
+            Self::Newline(s) => write!(f, "Newline({s})"),
             Self::Word(s) => write!(f, "Word({s})"),
             Self::UnicodeText(s) => write!(f, "UnicodeText({s})"),
             Self::Error => write!(f, "Error"),
@@ -132,8 +136,9 @@ mod tests {
             };
         }
 
-        // Control characters (0x00-0x08, 0x0A-0x1F, 0x7F) are not explicitly tokenized
+        // Control characters (0x00-0x08, 0x0B-0x1F, 0x7F) are not explicitly tokenized
         // They will be matched as Error tokens
+        // Note: 0x0A (LF) is handled as Token::Newline, 0x0D (CR) is handled as part of CRLF
         // Symbol now matches multiple consecutive characters
         test_ascii_range!(test_ascii_chars_09_09, 0x09..=0x09, Symbol, false);
         test_ascii_range!(test_ascii_chars_20_21, 0x20..=0x21, Symbol, false);
@@ -196,10 +201,50 @@ mod tests {
             Word("WORD1"),
             Word("WORD2"),
             Word("WORD3"),
-            Newline,
+            Newline("\r\n"),
             Word("WORD4"),
         ];
         assert_tokenize(src, &expected);
+    }
+
+    #[test]
+    fn handles_lf_line_folding() {
+        // Line folding with bare LF (LF + space/tab) should also be skipped
+        let src = "WORD1\n WORD2\n\tWORD3\nWORD4";
+        let expected = [
+            Word("WORD1"),
+            Word("WORD2"),
+            Word("WORD3"),
+            Newline("\n"),
+            Word("WORD4"),
+        ];
+        assert_tokenize(src, &expected);
+    }
+
+    #[test]
+    fn tokenizes_lf_line_endings() {
+        // Multiple consecutive LF sequences should produce Newline tokens
+        let tokens = tokenize_with_errors("WORD1\n\nWORD2");
+        assert_eq!(
+            tokens,
+            vec![Word("WORD1"), Newline("\n"), Newline("\n"), Word("WORD2")]
+        );
+    }
+
+    #[test]
+    fn tokenizes_mixed_crlf_and_lf() {
+        // Mixed CRLF and LF line endings should both produce Newline tokens
+        let tokens = tokenize_with_errors("WORD1\r\nWORD2\nWORD3");
+        assert_eq!(
+            tokens,
+            vec![
+                Word("WORD1"),
+                Newline("\r\n"),
+                Word("WORD2"),
+                Newline("\n"),
+                Word("WORD3")
+            ]
+        );
     }
 
     #[test]
@@ -256,7 +301,7 @@ mod tests {
     #[test]
     fn tokenizes_control_chars_as_error() {
         // Control characters (except HTAB) should produce Error tokens
-        // CONTROL = %x00-08 / %x0A-1F / %x7F
+        // CONTROL = %x00-08 / %x0B-1F / %x7F
 
         // Test NULL (0x00)
         let tokens = tokenize_with_errors("\x00");
@@ -266,9 +311,9 @@ mod tests {
         let tokens = tokenize_with_errors("\x07");
         assert_eq!(tokens, vec![Error]);
 
-        // Test Line Feed alone (0x0A) - not part of CRLF
+        // Test Line Feed (0x0A) - now accepted as Newline
         let tokens = tokenize_with_errors("\n");
-        assert_eq!(tokens, vec![Error]);
+        assert_eq!(tokens, vec![Newline("\n")]);
 
         // Test Escape (0x1B)
         let tokens = tokenize_with_errors("\x1B");
@@ -294,10 +339,10 @@ mod tests {
     }
 
     #[test]
-    fn tokenizes_lf_without_cr_as_error() {
-        // LF without preceding CR should be an error
+    fn tokenizes_lf_without_cr_as_newline() {
+        // LF without preceding CR should be accepted as Newline
         let tokens = tokenize_with_errors("WORD1\nWORD2");
-        assert_eq!(tokens, vec![Word("WORD1"), Error, Word("WORD2")]);
+        assert_eq!(tokens, vec![Word("WORD1"), Newline("\n"), Word("WORD2")]);
     }
 
     #[test]
@@ -314,14 +359,22 @@ mod tests {
     fn tokenizes_valid_crlf_sequence() {
         // Valid CRLF sequence should produce Newline token
         let tokens = tokenize_with_errors("WORD1\r\nWORD2");
-        assert_eq!(tokens, vec![Word("WORD1"), Newline, Word("WORD2")]);
+        assert_eq!(tokens, vec![Word("WORD1"), Newline("\r\n"), Word("WORD2")]);
     }
 
     #[test]
     fn tokenizes_multiple_crlf_sequences() {
         // Multiple consecutive CRLF sequences
         let tokens = tokenize_with_errors("WORD1\r\n\r\nWORD2");
-        assert_eq!(tokens, vec![Word("WORD1"), Newline, Newline, Word("WORD2")]);
+        assert_eq!(
+            tokens,
+            vec![
+                Word("WORD1"),
+                Newline("\r\n"),
+                Newline("\r\n"),
+                Word("WORD2")
+            ]
+        );
     }
 
     #[test]

--- a/ical/src/syntax/scanner.rs
+++ b/ical/src/syntax/scanner.rs
@@ -39,6 +39,7 @@ use std::fmt;
 use std::iter::Peekable;
 
 use crate::string_storage::{Segments, Span};
+use crate::syntax::ParseOptions;
 use crate::syntax::lexer::{SpannedToken, Token};
 
 /// A scanned iCalendar content line.
@@ -135,6 +136,15 @@ pub enum ContentLineError {
         /// Description of the issue
         message: String,
     },
+
+    /// Bare LF line ending (without preceding CR).
+    ///
+    /// RFC 5545 requires CRLF line endings. This error is only reported
+    /// when [`ParseOptions::strict_line_endings`] is `true`.
+    BareLineEnding {
+        /// Span of the bare LF character
+        span: Span,
+    },
 }
 
 impl fmt::Display for ContentLineError {
@@ -152,6 +162,9 @@ impl fmt::Display for ContentLineError {
                 write!(f, "{msg}")
             }
             ContentLineError::MalformedLine { message, .. } => write!(f, "{message}"),
+            ContentLineError::BareLineEnding { .. } => {
+                write!(f, "bare LF line ending; iCalendar requires CRLF (\\r\\n)")
+            }
         }
     }
 }
@@ -222,13 +235,14 @@ pub struct ScanResult<'src> {
 pub fn scan_content_lines<'src>(
     src: &'src str,
     tokens: impl IntoIterator<Item = SpannedToken<'src>>,
+    options: ParseOptions,
 ) -> ScanResult<'src> {
     let mut token_iter = tokens.into_iter().peekable();
     let mut lines = Vec::new();
     let mut has_errors = false;
 
     while token_iter.peek().is_some() {
-        match scan_one_content_line(src, &mut token_iter) {
+        match scan_one_content_line(src, &mut token_iter, options) {
             Some(line) => {
                 if line.error.is_some() {
                     has_errors = true;
@@ -248,6 +262,7 @@ pub fn scan_content_lines<'src>(
 fn scan_one_content_line<'src>(
     src: &'src str,
     tokens: &mut Peekable<impl Iterator<Item = SpannedToken<'src>>>,
+    options: ParseOptions,
 ) -> Option<ContentLine<'src>> {
     // Peek at first token to determine if we have content
     let first_token = *tokens.peek()?;
@@ -270,19 +285,25 @@ fn scan_one_content_line<'src>(
     }
 
     // Check if this is an empty line (just newline)
-    if matches!(first_token.0, Token::Newline) {
-        let newline = tokens.next()?;
+    if matches!(first_token.0, Token::Newline(_)) {
+        let Some(SpannedToken(token, span)) = tokens.next() else {
+            unreachable!()
+        };
+
+        // Check for bare LF in strict mode
+        let bare_lf_error = check_bare_line_ending(token, span, options);
+
         return Some(ContentLine {
             name: Segments::default(),
             parameters: Vec::new(),
             value: Segments::default(),
-            span: newline.1,
-            error: Some(ContentLineError::EmptyLine { span: newline.1 }),
+            span,
+            error: bare_lf_error.or(Some(ContentLineError::EmptyLine { span })),
         });
     }
 
     // Parse: name [;param]* : value \r\n
-    let result = parse_content_line_structure(src, tokens, line_start);
+    let result = parse_content_line_structure(src, tokens, line_start, options);
 
     Some(result)
 }
@@ -292,6 +313,7 @@ fn parse_content_line_structure<'src>(
     src: &'src str,
     tokens: &mut Peekable<impl Iterator<Item = SpannedToken<'src>>>,
     line_start: Span,
+    options: ParseOptions,
 ) -> ContentLine<'src> {
     // Parse name (sequence of Word tokens)
     let (name, _name_span) = parse_property_name(tokens);
@@ -374,15 +396,18 @@ fn parse_content_line_structure<'src>(
 
     // Expect and consume newline
     match tokens.next() {
-        Some(SpannedToken(Token::Newline, newline_span)) => {
+        Some(SpannedToken(Token::Newline(nl), newline_span)) => {
             let line_end = newline_span.end;
+
+            // Check for bare LF in strict mode
+            let bare_lf_error = check_bare_line_ending(Token::Newline(nl), newline_span, options);
 
             ContentLine {
                 name,
                 parameters,
                 value,
                 span: Span::new(line_start.start, line_end),
-                error: None,
+                error: bare_lf_error,
             }
         }
         // Missing newline - still return content line with what we have
@@ -556,7 +581,11 @@ fn parse_parameter_value<'src>(
         // Collect until separator (semicolon, colon, comma, equals, newline)
         while let Some(token) = tokens.peek() {
             match token.0 {
-                Token::Semicolon | Token::Colon | Token::Comma | Token::Equal | Token::Newline => {
+                Token::Semicolon
+                | Token::Colon
+                | Token::Comma
+                | Token::Equal
+                | Token::Newline(_) => {
                     break;
                 }
                 _ => {
@@ -593,7 +622,7 @@ fn parse_value<'src>(
 
     // Collect all tokens until newline
     while let Some(token) = tokens.peek() {
-        if matches!(token.0, Token::Newline) {
+        if matches!(token.0, Token::Newline(_)) {
             break;
         }
         if matches!(token.0, Token::Error) {
@@ -634,7 +663,7 @@ fn get_current_end<'a>(tokens: &mut Peekable<impl Iterator<Item = SpannedToken<'
 /// This is used in error recovery to avoid infinite loops when errors occur.
 fn consume_until_newline<'a>(tokens: &mut Peekable<impl Iterator<Item = SpannedToken<'a>>>) {
     for SpannedToken(token, _) in tokens.by_ref() {
-        if matches!(token, Token::Newline) {
+        if matches!(token, Token::Newline(_)) {
             break;
         }
     }
@@ -655,10 +684,6 @@ fn token_to_text(token: Token<'_>) -> &str {
 
 fn invalid_token_message(src: &str, span: Span) -> String {
     match src.get(span.into_range()) {
-        Some("\n") => {
-            "invalid line ending: found LF without preceding CR; iCalendar requires CRLF (\\r\\n)"
-                .to_string()
-        }
         Some("\r") => {
             "invalid line ending: found CR without following LF; iCalendar requires CRLF (\\r\\n)"
                 .to_string()
@@ -668,6 +693,30 @@ fn invalid_token_message(src: &str, span: Span) -> String {
             invalid.escape_debug().to_string()
         ),
         None => "invalid token in content line".to_string(),
+    }
+}
+
+/// Check whether a newline token corresponds to a bare LF (not CRLF).
+///
+/// Returns `Some(ContentLineError::BareLineEnding)` if strict mode is on and
+/// the newline slice is `"\n"` instead of `"\r\n"`.
+fn check_bare_line_ending(
+    token: Token<'_>,
+    span: Span,
+    options: ParseOptions,
+) -> Option<ContentLineError> {
+    match token {
+        Token::Newline("\r\n") => None, // valid CRLF
+        Token::Newline(_) if options.strict_line_endings => {
+            Some(ContentLineError::BareLineEnding { span })
+        }
+        Token::Newline(_) => None,
+        t => Some(ContentLineError::MalformedLine {
+            span,
+            message: format!(
+                "invalid line ending: expected CRLF (\\r\\n) or LF (\\n), found {t:?}",
+            ),
+        }),
     }
 }
 
@@ -684,6 +733,10 @@ mod tests {
     use crate::syntax::lexer::{SpannedToken, Token};
 
     fn test_scan(src: &str) -> ScanResult<'_> {
+        test_scan_with_options(src, ParseOptions::default())
+    }
+
+    fn test_scan_with_options(src: &str, options: ParseOptions) -> ScanResult<'_> {
         let tokens: Vec<_> = Token::lexer(src)
             .spanned()
             .map(|(tok, span)| {
@@ -697,7 +750,7 @@ mod tests {
                 }
             })
             .collect();
-        scan_content_lines(src, tokens)
+        scan_content_lines(src, tokens, options)
     }
 
     fn component_name<'src>(line: &ContentLine<'src>) -> Option<Cow<'src, str>> {
@@ -990,24 +1043,21 @@ END:VCALENDAR\r\n";
     }
 
     #[test]
-    fn scanner_reports_bare_lf_line_endings() {
-        let src = "BEGIN:VCALENDAR\nEND:VCALENDAR\n";
+    fn scanner_accepts_lf_line_endings() {
+        let src = "BEGIN:VCALENDAR\nVERSION:2.0\nEND:VCALENDAR\n";
         let result = test_scan(src);
 
-        assert!(result.has_errors);
-        let error = result
-            .lines
-            .iter()
-            .find_map(|line| match &line.error {
-                Some(ContentLineError::MalformedLine { message, .. })
-                    if message.contains("LF without preceding CR") =>
-                {
-                    Some(message)
-                }
-                _ => None,
-            })
-            .expect("Expected bare LF line-ending error");
-        assert!(error.contains("CRLF"));
+        assert!(!result.has_errors);
+        assert_eq!(result.lines.len(), 3);
+
+        assert!(result.lines[0].name.eq_str_ignore_ascii_case("BEGIN"));
+        assert_eq!(result.lines[0].value.resolve().as_ref(), "VCALENDAR");
+
+        assert_eq!(result.lines[1].name.to_owned(), "VERSION");
+        assert_eq!(result.lines[1].value.to_owned(), "2.0");
+
+        assert!(result.lines[2].name.eq_str_ignore_ascii_case("END"));
+        assert_eq!(result.lines[2].value.resolve().as_ref(), "VCALENDAR");
     }
 
     #[test]
@@ -1029,5 +1079,79 @@ END:VCALENDAR\r\n";
             })
             .expect("Expected bare CR line-ending error");
         assert!(error.contains("CRLF"));
+    }
+
+    #[test]
+    fn scanner_handles_lf_line_folding() {
+        // LF followed by space/tab should be treated as line folding (same as CRLF).
+        // The logos lexer skips the entire \n<space> sequence, so the leading space
+        // on the continuation line is consumed.
+        let src = "DESCRIPTION:This is a long description that is\n folded across two lines\n";
+        let result = test_scan(src);
+
+        assert!(!result.has_errors);
+        assert_eq!(result.lines.len(), 1);
+        assert_eq!(result.lines[0].name.to_owned(), "DESCRIPTION");
+        // The folded content should be merged (note: the leading space is consumed by logos)
+        assert_eq!(
+            result.lines[0].value.resolve().as_ref(),
+            "This is a long description that isfolded across two lines"
+        );
+    }
+
+    #[test]
+    fn scanner_handles_mixed_crlf_and_lf() {
+        // Mixed line endings should both be accepted
+        let src = "BEGIN:VCALENDAR\r\nVERSION:2.0\nEND:VCALENDAR\r\n";
+        let result = test_scan(src);
+
+        assert!(!result.has_errors);
+        assert_eq!(result.lines.len(), 3);
+    }
+
+    #[test]
+    fn scanner_strict_mode_rejects_bare_lf() {
+        let src = "BEGIN:VCALENDAR\nVERSION:2.0\nEND:VCALENDAR\n";
+        let opts = ParseOptions::new().strict_line_endings(true);
+        let result = test_scan_with_options(src, opts);
+
+        assert!(result.has_errors);
+        // All three lines use bare LF, so all three should have errors
+        let bare_lf_errors: Vec<_> = result
+            .lines
+            .iter()
+            .filter(|line| matches!(&line.error, Some(ContentLineError::BareLineEnding { .. })))
+            .collect();
+        assert!(
+            !bare_lf_errors.is_empty(),
+            "Expected bare LF errors in strict mode"
+        );
+    }
+
+    #[test]
+    fn scanner_strict_mode_accepts_crlf() {
+        let src = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nEND:VCALENDAR\r\n";
+        let opts = ParseOptions::new().strict_line_endings(true);
+        let result = test_scan_with_options(src, opts);
+
+        assert!(!result.has_errors);
+        assert_eq!(result.lines.len(), 3);
+    }
+
+    #[test]
+    fn scanner_strict_mode_reports_mixed_endings() {
+        let src = "BEGIN:VCALENDAR\r\nVERSION:2.0\nEND:VCALENDAR\r\n";
+        let opts = ParseOptions::new().strict_line_endings(true);
+        let result = test_scan_with_options(src, opts);
+
+        assert!(result.has_errors);
+        // Only the VERSION line uses bare LF
+        let bare_lf_errors: Vec<_> = result
+            .lines
+            .iter()
+            .filter(|line| matches!(&line.error, Some(ContentLineError::BareLineEnding { .. })))
+            .collect();
+        assert_eq!(bare_lf_errors.len(), 1);
+        assert_eq!(bare_lf_errors[0].name.to_owned(), "VERSION");
     }
 }

--- a/ical/src/syntax/tree_builder.rs
+++ b/ical/src/syntax/tree_builder.rs
@@ -301,6 +301,7 @@ mod tests {
     use logos::Logos;
 
     use crate::string_storage::Span;
+    use crate::syntax::ParseOptions;
     use crate::syntax::lexer::{SpannedToken, Token};
     use crate::syntax::scanner::scan_content_lines;
 
@@ -322,7 +323,7 @@ mod tests {
             .collect();
 
         // Import scan_content_lines from scanner module
-        let scan_result = scan_content_lines(src, tokens);
+        let scan_result = scan_content_lines(src, tokens, ParseOptions::default());
 
         build_tree(&scan_result.lines)
     }
@@ -545,6 +546,7 @@ END:VCALENDAR\r\n";
 
     #[test]
     fn tree_builder_ignores_error_lines() {
+        use crate::syntax::ParseOptions;
         use crate::syntax::scanner::scan_content_lines;
 
         let src = "BEGIN:VCALENDAR\r\n\
@@ -565,7 +567,7 @@ END:VCALENDAR\r\n";
                 }
             })
             .collect();
-        let scan_result = scan_content_lines(src, tokens);
+        let scan_result = scan_content_lines(src, tokens, ParseOptions::default());
 
         // Second line should have an error (missing colon)
         assert!(scan_result.lines[1].error.is_some());

--- a/ical/tests/syntax.rs
+++ b/ical/tests/syntax.rs
@@ -7,7 +7,9 @@
 //! These tests validate the syntax parser's behavior on realistic iCalendar content
 //! and edge cases.
 
-use aimcal_ical::syntax::{RawComponent, syntax_analysis};
+use aimcal_ical::syntax::{
+    ParseOptions, RawComponent, syntax_analysis, syntax_analysis_with_options,
+};
 
 /// Test helper to parse and get the first component
 fn parse_first_component(src: &str) -> RawComponent<'_> {
@@ -231,17 +233,17 @@ END:VCALENDAR\r
 }
 
 #[test]
-fn syntax_reports_bare_lf_line_endings() {
+fn syntax_reports_bare_lf_line_endings_in_strict_mode() {
     let src = "BEGIN:VCALENDAR\nEND:VCALENDAR\n";
-    let err = syntax_analysis(src).expect_err("Expected bare LF input to fail");
+    let opts = ParseOptions::new().strict_line_endings(true);
+    let err = syntax_analysis_with_options(src, opts).expect_err("Expected bare LF input to fail");
     let rendered = err
         .iter()
         .map(ToString::to_string)
         .collect::<Vec<_>>()
         .join("\n");
 
-    assert!(rendered.contains("LF without preceding CR"));
-    assert!(rendered.contains("CRLF"));
+    assert!(rendered.contains("bare LF"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

While RFC 5545 specifies CRLF (`\r\n`) as the mandatory line ending, many real-world iCalendar files use bare LF (`\n`). This change makes the parser accept both for compatibility.

## Changes

- **lexer**: Recognize bare LF (`0x0A`) as `Token::Newline` alongside CRLF
- **lexer**: Support line folding with LF prefix (`\n` + space/tab)
- **scanner**: Remove bare LF error, accept LF as valid line ending
- **tests**: Add coverage for LF-only, mixed CRLF/LF, and LF line folding inputs

## Files

- `ical/src/syntax/lexer.rs` — Newline token + line folding skip regex
- `ical/src/syntax/scanner.rs` — Remove LF error message, update tests