### PR TITLE
🐛 Fix relative path resolution in config and enforce state_dir in dev mode

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -55,7 +55,11 @@ pub async fn parse_config(path: Option<PathBuf>) -> Result<(CoreConfig, Config),
         .await
         .map_err(|e| format!("Failed to read config file at {}: {}", path.display(), e))?
         .parse::<ConfigRaw>()
-        .map(|a| (a.core, Config {}))
+        .map(|mut a| {
+            a.core.config_dir = path.parent().map(PathBuf::from);
+            a.core.dev_mode = is_dev_mode().unwrap_or(false);
+            (a.core, Config {})
+        })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -35,6 +35,20 @@ pub struct Config {
     /// If true, items with no priority will be listed first.
     #[serde(default)]
     pub default_priority_none_fist: bool,
+
+    /// Parent directory of the config file.
+    ///
+    /// Set by the CLI layer after parsing. Used by `normalize()` to resolve
+    /// relative paths against the config file location rather than the CWD.
+    #[serde(skip)]
+    pub config_dir: Option<PathBuf>,
+
+    /// Whether development mode is active.
+    ///
+    /// When true, `normalize()` enforces explicit `state_dir` configuration
+    /// to prevent accidental use of the system default state directory.
+    #[serde(skip)]
+    pub dev_mode: bool,
 }
 
 impl Config {
@@ -44,30 +58,39 @@ impl Config {
     /// If path normalization fails.
     #[tracing::instrument(skip(self))]
     pub fn normalize(&mut self) -> Result<(), Box<dyn Error>> {
+        let config_parent = self.config_dir.as_deref();
+
         // Normalize calendar path if set
         if let Some(ref calendar_path) = self.calendar_path {
-            self.calendar_path = Some(expand_path(calendar_path)?);
+            self.calendar_path = Some(expand_path(calendar_path, config_parent)?);
         }
 
         // Normalize state directory
-        match &self.state_dir {
-            Some(a) => {
-                let state_dir = expand_path(a)
-                    .map_err(|e| format!("Failed to expand state directory path: {e}"))?;
-                self.state_dir = Some(state_dir);
+        if let Some(a) = &self.state_dir {
+            let state_dir = expand_path(a, config_parent)
+                .map_err(|e| format!("Failed to expand state directory path: {e}"))?;
+            self.state_dir = Some(state_dir);
+        } else {
+            if self.dev_mode {
+                return Err(
+                    "Development mode requires state_dir to be explicitly configured".into(),
+                );
             }
-            None => match get_state_dir() {
+            match get_state_dir() {
                 Ok(a) => self.state_dir = Some(a.join(APP_NAME)),
                 Err(err) => tracing::warn!(err, "failed to get state directory"),
-            },
+            }
         }
 
         Ok(())
     }
 }
 
-/// Handle tilde (~) and environment variables in the path
-fn expand_path(path: &Path) -> Result<PathBuf, Box<dyn Error>> {
+/// Handle tilde (~) and environment variables in the path.
+///
+/// Relative paths that don't match any special prefix are resolved against
+/// `config_parent` when provided, or returned as-is otherwise.
+fn expand_path(path: &Path, config_parent: Option<&Path>) -> Result<PathBuf, Box<dyn Error>> {
     if path.is_absolute() {
         return Ok(path.to_owned());
     }
@@ -98,7 +121,10 @@ fn expand_path(path: &Path) -> Result<PathBuf, Box<dyn Error>> {
         }
     }
 
-    Ok(path.into())
+    match config_parent {
+        Some(parent) => Ok(parent.join(path)),
+        None => Ok(path.into()),
+    }
 }
 
 fn get_home_dir() -> Result<PathBuf, Box<dyn Error>> {
@@ -168,7 +194,7 @@ default_priority_none_fist = true
             &[r"~", r"%UserProfile%"]
         };
         for prefix in home_prefixes {
-            let result = expand_path(&PathBuf::from(format!("{prefix}/Documents"))).unwrap();
+            let result = expand_path(&PathBuf::from(format!("{prefix}/Documents")), None).unwrap();
             assert_eq!(result, home.join("Documents"));
             assert!(result.is_absolute());
         }
@@ -183,7 +209,8 @@ default_priority_none_fist = true
             &[r"%LOCALAPPDATA%"]
         };
         for prefix in config_prefixes {
-            let result = expand_path(&PathBuf::from(format!("{prefix}/config.toml"))).unwrap();
+            let result =
+                expand_path(&PathBuf::from(format!("{prefix}/config.toml")), None).unwrap();
             assert_eq!(result, config_dir.join("config.toml"));
             assert!(result.is_absolute());
         }
@@ -192,15 +219,24 @@ default_priority_none_fist = true
     #[test]
     fn preserves_absolute_path() {
         let absolute_path = PathBuf::from("/etc/passwd");
-        let result = expand_path(&absolute_path).unwrap();
+        let result = expand_path(&absolute_path, None).unwrap();
         assert_eq!(result, absolute_path);
     }
 
     #[test]
-    fn preserves_relative_path() {
+    fn preserves_relative_path_without_config_parent() {
         let relative_path = PathBuf::from("relative/path/to/file");
-        let result = expand_path(&relative_path).unwrap();
+        let result = expand_path(&relative_path, None).unwrap();
         assert_eq!(result, relative_path);
+    }
+
+    #[test]
+    fn resolves_relative_path_against_config_parent() {
+        let relative_path = PathBuf::from("relative/path/to/file");
+        let config_parent = PathBuf::from("/etc/aim");
+
+        let result = expand_path(&relative_path, Some(&config_parent)).unwrap();
+        assert_eq!(result, PathBuf::from("/etc/aim/relative/path/to/file"));
     }
 
     #[test]

--- a/core/tests/aim/events.rs
+++ b/core/tests/aim/events.rs
@@ -23,6 +23,8 @@ async fn aim_new_event_creates_file_and_database_entry() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -55,6 +57,8 @@ async fn aim_get_event_resolves_short_id() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -83,6 +87,8 @@ async fn aim_update_event_modifies_file_and_database() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -120,6 +126,8 @@ async fn aim_list_events_returns_all_events() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -164,6 +172,8 @@ async fn aim_list_events_with_pagination() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -230,6 +240,8 @@ async fn aim_count_events_returns_correct_count() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -270,6 +282,8 @@ async fn aim_new_event_assigns_sequential_short_ids() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -298,6 +312,8 @@ async fn aim_update_event_clears_optional_fields() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -335,6 +351,8 @@ async fn aim_get_event_returns_error_for_nonexistent() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -353,6 +371,8 @@ async fn aim_update_event_returns_error_for_nonexistent() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -377,6 +397,8 @@ async fn aim_event_status_updates_correctly() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -413,6 +435,8 @@ async fn aim_event_with_custom_datetimes() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -441,6 +465,8 @@ async fn aim_flush_short_ids_removes_mappings() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -477,6 +503,8 @@ async fn aim_update_db_only_event_without_calendar_path_succeeds() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -523,6 +551,8 @@ async fn aim_update_db_only_event_with_calendar_path_creates_ics_file() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim_no_calendar = Aim::new(config_no_calendar).await.unwrap();
 
@@ -540,6 +570,8 @@ async fn aim_update_db_only_event_with_calendar_path_creates_ics_file() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config_with_calendar).await.unwrap();
 
@@ -578,6 +610,8 @@ async fn aim_update_db_only_event_status_updates_correctly() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 

--- a/core/tests/aim/lifecycle.rs
+++ b/core/tests/aim/lifecycle.rs
@@ -45,6 +45,8 @@ END:VCALENDAR\r
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -92,6 +94,8 @@ async fn aim_new_creates_empty_state_without_calendar_files() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -122,6 +126,8 @@ async fn aim_now_returns_initial_time() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -144,6 +150,8 @@ async fn aim_refresh_now_updates_current_time() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let mut aim = Aim::new(config).await.unwrap();
 
@@ -172,6 +180,8 @@ async fn aim_close_cleans_up_database() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -226,6 +236,8 @@ async fn aim_default_event_draft_creates_draft_with_now() {
         default_due: Some(DateTimeAnchor::InDays(1)),
         default_priority: Priority::P5,
         default_priority_none_fist: true,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -254,6 +266,8 @@ async fn aim_default_todo_draft_includes_config_defaults() {
         default_due: Some(DateTimeAnchor::InDays(7)),
         default_priority: Priority::P2,
         default_priority_none_fist: true,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -305,6 +319,8 @@ END:VCALENDAR\r
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -361,6 +377,8 @@ END:VCALENDAR\r
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 

--- a/core/tests/aim/todos.rs
+++ b/core/tests/aim/todos.rs
@@ -23,6 +23,8 @@ async fn aim_new_todo_creates_file_and_database_entry() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -55,6 +57,8 @@ async fn aim_get_todo_resolves_short_id() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -83,6 +87,8 @@ async fn aim_update_todo_modifies_file_and_database() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -117,6 +123,8 @@ async fn aim_list_todos_returns_all_todos() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -162,6 +170,8 @@ async fn aim_list_todos_with_pagination() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -231,6 +241,8 @@ async fn aim_count_todos_returns_correct_count() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -271,6 +283,8 @@ async fn aim_default_todo_draft_uses_config_defaults() {
         default_due: Some(DateTimeAnchor::InDays(7)),
         default_priority: Priority::P2,
         default_priority_none_fist: true,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -290,6 +304,8 @@ async fn aim_update_todo_clears_optional_fields() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -324,6 +340,8 @@ async fn aim_update_todo_status_to_completed_sets_completed_timestamp() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -361,6 +379,8 @@ async fn aim_update_todo_status_from_completed_clears_completed_timestamp() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -404,6 +424,8 @@ async fn aim_list_todos_with_status_filter() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -453,6 +475,8 @@ async fn aim_list_todos_with_priority_sort() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -503,6 +527,8 @@ async fn aim_get_todo_returns_error_for_nonexistent() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -521,6 +547,8 @@ async fn aim_update_todo_returns_error_for_nonexistent() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -548,6 +576,8 @@ async fn aim_update_db_only_todo_without_calendar_path_succeeds() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -591,6 +621,8 @@ async fn aim_update_db_only_todo_with_calendar_path_creates_ics_file() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim_no_calendar = Aim::new(config_no_calendar).await.unwrap();
 
@@ -608,6 +640,8 @@ async fn aim_update_db_only_todo_with_calendar_path_creates_ics_file() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config_with_calendar).await.unwrap();
 
@@ -643,6 +677,8 @@ async fn aim_update_db_only_todo_status_to_completed_sets_timestamp() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 

--- a/core/tests/common/fixtures.rs
+++ b/core/tests/common/fixtures.rs
@@ -33,6 +33,8 @@ pub fn test_config(calendar_path: &str, state_dir: Option<&str>) -> Config {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     }
 }
 
@@ -55,6 +57,8 @@ pub fn test_config_with_due(
         default_due: Some(default_due),
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     }
 }
 
@@ -67,6 +71,8 @@ pub fn test_config_defaults() -> Config {
         default_due: Some(DateTimeAnchor::InDays(1)),
         default_priority: Priority::P5,
         default_priority_none_fist: true,
+        config_dir: None,
+        dev_mode: false,
     }
 }
 
@@ -255,6 +261,8 @@ impl TestConfigBuilder {
             default_due: self.default_due,
             default_priority: self.default_priority,
             default_priority_none_fist: self.default_priority_none_fist,
+            config_dir: None,
+            dev_mode: false,
         }
     }
 }

--- a/core/tests/workflows/config_driven.rs
+++ b/core/tests/workflows/config_driven.rs
@@ -60,6 +60,8 @@ async fn config_default_due_applied() {
         default_due: Some(DateTimeAnchor::InDays(7)),
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -108,6 +110,8 @@ async fn config_default_priority_applied() {
             default_due: None,
             default_priority,
             default_priority_none_fist: false,
+            config_dir: None,
+            dev_mode: false,
         };
         let aim = Aim::new(config).await.unwrap();
 
@@ -131,6 +135,8 @@ async fn config_priority_sorting_behavior() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: true,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim_none_first = Aim::new(config_none_first).await.unwrap();
 
@@ -176,6 +182,8 @@ async fn config_priority_sorting_behavior() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim_some_first = Aim::new(config_some_first).await.unwrap();
 
@@ -219,6 +227,8 @@ async fn config_timezone_handling() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -247,6 +257,8 @@ async fn config_mixed_defaults_integration() {
         default_due: Some(DateTimeAnchor::InDays(7)),
         default_priority: Priority::P3,
         default_priority_none_fist: true,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -305,6 +317,8 @@ async fn config_persistence_across_restarts() {
         default_due: Some(DateTimeAnchor::InDays(7)),
         default_priority: Priority::P5,
         default_priority_none_fist: true,
+        config_dir: None,
+        dev_mode: false,
     };
 
     // First instance - create todos
@@ -346,6 +360,8 @@ async fn config_default_draft_consistency() {
         default_due: Some(DateTimeAnchor::InDays(1)),
         default_priority: Priority::P2,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -380,6 +396,8 @@ async fn config_event_defaults() {
         default_due: Some(DateTimeAnchor::InDays(7)),
         default_priority: Priority::P5,
         default_priority_none_fist: true,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -419,6 +437,8 @@ async fn config_datetime_anchor_variations() {
             default_due: Some(anchor.clone()),
             default_priority: Priority::None,
             default_priority_none_fist: false,
+            config_dir: None,
+            dev_mode: false,
         };
         let aim = Aim::new(config).await.unwrap();
 

--- a/core/tests/workflows/event_lifecycle.rs
+++ b/core/tests/workflows/event_lifecycle.rs
@@ -29,6 +29,8 @@ async fn event_lifecycle_create_flow() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
     let draft = test_event_draft("Team Meeting");
@@ -68,6 +70,8 @@ async fn event_lifecycle_update_flow() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
     let draft = test_event_draft("Original Title");
@@ -111,6 +115,8 @@ async fn event_lifecycle_external_modification_detected() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
     let draft = test_event_draft("External Test");
@@ -152,6 +158,8 @@ async fn event_lifecycle_status_transitions() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
     let draft = test_event_draft("Status Test");
@@ -206,6 +214,8 @@ async fn event_lifecycle_batch_operations() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -317,6 +327,8 @@ END:VCALENDAR
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -353,6 +365,8 @@ async fn event_lifecycle_rebuild_from_files() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
 
     // Create initial Aim instance and events
@@ -411,6 +425,8 @@ async fn event_lifecycle_with_custom_datetimes() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 

--- a/core/tests/workflows/file_sync.rs
+++ b/core/tests/workflows/file_sync.rs
@@ -28,6 +28,8 @@ async fn file_sync_external_modification_detected() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config.clone()).await.unwrap();
 
@@ -94,6 +96,8 @@ async fn file_sync_database_rebuild_from_files() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
 
     // Create multiple events and todos
@@ -192,6 +196,8 @@ async fn file_sync_add_remove_calendar_files() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config.clone()).await.unwrap();
 
@@ -295,6 +301,8 @@ async fn file_sync_corrupted_file_handling() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
 
     // Create valid files
@@ -372,6 +380,8 @@ async fn file_sync_mixed_components_in_single_file() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
 
     // Create file with multiple components
@@ -464,6 +474,8 @@ async fn file_sync_empty_directory_handling() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
 
     // Act - load empty directory
@@ -512,6 +524,8 @@ async fn file_sync_non_ics_files_ignored() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
 
     // Create valid .ics file
@@ -583,6 +597,8 @@ async fn file_sync_persistence_across_restarts() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
 
     // First run - create data

--- a/core/tests/workflows/todo_lifecycle.rs
+++ b/core/tests/workflows/todo_lifecycle.rs
@@ -25,6 +25,8 @@ async fn todo_lifecycle_create_with_config_defaults() {
         default_due: Some(DateTimeAnchor::InDays(7)),
         default_priority: Priority::P2,
         default_priority_none_fist: true,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -58,6 +60,8 @@ async fn todo_lifecycle_status_evolution() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
     let draft = test_todo_draft("Workflow Task");
@@ -111,6 +115,8 @@ async fn todo_lifecycle_priority_handling() {
         default_due: None,
         default_priority: Priority::P5,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -147,6 +153,8 @@ async fn todo_lifecycle_sorting() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: true,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -230,6 +238,8 @@ async fn todo_lifecycle_filtering() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -323,6 +333,8 @@ async fn todo_lifecycle_batch_operations() {
         default_due: Some(DateTimeAnchor::InDays(1)),
         default_priority: Priority::P5,
         default_priority_none_fist: true,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -391,6 +403,8 @@ async fn todo_lifecycle_percent_complete_validation() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -476,6 +490,8 @@ async fn todo_lifecycle_metadata_updates() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -550,6 +566,8 @@ async fn todo_lifecycle_with_due_dates() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
     let aim = Aim::new(config).await.unwrap();
 
@@ -585,6 +603,8 @@ async fn todo_lifecycle_rebuild_from_files() {
         default_due: None,
         default_priority: Priority::None,
         default_priority_none_fist: false,
+        config_dir: None,
+        dev_mode: false,
     };
 
     // Create initial todos


### PR DESCRIPTION
This pull request improves configuration handling by making path normalization more robust and context-aware, particularly for development mode and relative paths.

These changes make configuration handling safer, especially for development, and ensure that relative paths in the config file are interpreted as intended.