### PR TITLE
build(ical): bump chumsky from 0.12.0 to 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- ical: Bump chumsky from 0.12.0 to 0.13.0, replacing `Container` trait with `FromIterator`
+  for `SpanCollector`
 - cli: Show past events in gray in dashboard; only color events for today
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -401,12 +401,12 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chumsky"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba4a05c9ce83b07de31b31c874e87c069881ac4355db9e752e3a55c11ec75a6"
+checksum = "e0d2bfadce76f963d776feff99db6dc33783829539258314776383b33e2a00f8"
 dependencies = [
  "hashbrown 0.15.4",
- "regex-automata 0.3.9",
+ "regex-automata",
  "serde",
  "stacker",
  "unicode-ident",
@@ -1905,8 +1905,8 @@ dependencies = [
  "fnv",
  "proc-macro2",
  "quote",
- "regex-automata 0.4.13",
- "regex-syntax 0.8.5",
+ "regex-automata",
+ "regex-syntax",
  "syn 2.0.117",
 ]
 
@@ -1950,7 +1950,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.4.13",
+ "regex-automata",
 ]
 
 [[package]]
@@ -2742,19 +2742,8 @@ checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.13",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax 0.7.5",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2765,14 +2754,8 @@ checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
@@ -3889,7 +3872,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata 0.4.13",
+ "regex-automata",
  "sharded-slab",
  "smallvec",
  "thread_local",

--- a/ical/Cargo.toml
+++ b/ical/Cargo.toml
@@ -13,7 +13,7 @@ repository.workspace = true
 readme.workspace = true
 
 [dependencies]
-chumsky = "0.12.0"
+chumsky = "0.13.0"
 jiff = { version = "0.2.24", optional = true }
 lexical = "7.0.5"
 logos = "0.16.1"

--- a/ical/src/value/text.rs
+++ b/ical/src/value/text.rs
@@ -8,7 +8,6 @@ use std::borrow::Cow;
 use std::fmt;
 
 use chumsky::Parser;
-use chumsky::container::Container;
 use chumsky::extra::ParserExtra;
 use chumsky::prelude::*;
 
@@ -363,18 +362,18 @@ impl SpanCollector {
     }
 }
 
-impl Container<SimpleSpan> for SpanCollector {
-    fn with_capacity(n: usize) -> Self {
-        Self(Vec::with_capacity(n))
-    }
-
-    fn push(&mut self, span: SimpleSpan) {
-        match self.0.last_mut() {
-            Some(last) if last.end() == span.start() => {
-                *last = SimpleSpan::new((), last.start()..span.end());
+impl FromIterator<SimpleSpan> for SpanCollector {
+    fn from_iter<I: IntoIterator<Item = SimpleSpan>>(iter: I) -> Self {
+        let mut spans: Vec<SimpleSpan> = Vec::new();
+        for span in iter {
+            match spans.last_mut() {
+                Some(last) if last.end() == span.start() => {
+                    *last = SimpleSpan::new((), last.start()..span.end());
+                }
+                _ => spans.push(span),
             }
-            _ => self.0.push(span),
         }
+        Self(spans)
     }
 }
 

--- a/scripts/add-worktree.sh
+++ b/scripts/add-worktree.sh
@@ -32,3 +32,6 @@ fi
 
 # Initialize development calendar in the new worktree
 cd "$worktree" && just init-dev
+
+echo "Worktree '$name' created at '$worktree', you can start working on it:"
+echo "  cd $worktree"


### PR DESCRIPTION
## Summary

- Bumps chumsky dependency from 0.12.0 to 0.13.0 in the `ical` crate
- Replaces the removed `Container` trait impl with `FromIterator<SimpleSpan>` for `SpanCollector` in `value/text.rs`

## Test plan

- [x] `cargo build -p aimcal-ical --all-features` compiles cleanly
- [x] `just test` — all 264 tests pass
- [x] `just lint` — no clippy warnings
- [x] `cargo fmt --check` — formatting clean

close #186